### PR TITLE
 Implement save product history one by one

### DIFF
--- a/boilerplate/package-lock.json
+++ b/boilerplate/package-lock.json
@@ -9,6 +9,7 @@
       "version": "1.0.0",
       "license": "ISC",
       "dependencies": {
+        "async": "^3.2.0",
         "bcryptjs": "^2.4.3",
         "body-parser": "^1.18.3",
         "cookie-parser": "^1.4.3",
@@ -197,6 +198,11 @@
       "engines": {
         "node": ">=0.10.0"
       }
+    },
+    "node_modules/async": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/async/-/async-3.2.0.tgz",
+      "integrity": "sha512-TR2mEZFVOj2pLStYxLht7TyfuRzaydfpxr3k9RpHIzMgw7A64dzsdqCxH1WJyQdoe8T10nDXd9wnEigmiuHIZw=="
     },
     "node_modules/async-each": {
       "version": "1.0.3",
@@ -5133,6 +5139,11 @@
       "resolved": "https://registry.npmjs.org/assign-symbols/-/assign-symbols-1.0.0.tgz",
       "integrity": "sha1-WWZ/QfrdTyDMvCu5a41Pf3jsA2c=",
       "dev": true
+    },
+    "async": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/async/-/async-3.2.0.tgz",
+      "integrity": "sha512-TR2mEZFVOj2pLStYxLht7TyfuRzaydfpxr3k9RpHIzMgw7A64dzsdqCxH1WJyQdoe8T10nDXd9wnEigmiuHIZw=="
     },
     "async-each": {
       "version": "1.0.3",

--- a/boilerplate/package.json
+++ b/boilerplate/package.json
@@ -16,6 +16,7 @@
   "author": "John ahn",
   "license": "ISC",
   "dependencies": {
+    "async": "^3.2.0",
     "bcryptjs": "^2.4.3",
     "body-parser": "^1.18.3",
     "cookie-parser": "^1.4.3",


### PR DESCRIPTION
1. 마이페이지 <사용가능>에서 상품 하나씩 처리
- 하나의 상품을 여러 개 구매했을 때 상품 한 개마다 아이디 지정
- 랜덤 문자열을 생성해서 아이디로 사용

- [x] 가게 주문수 업데이트
- 상품이 판매된 개수를 업데이트는 했으나, 가게에 총 주문수를 업데이트하진 못했다. 한 번에 두 컬렉션 업데이트가 불가해서 새로운 방법을 고안해야 한다.