### PR TITLE
Add reusable styled-components

### DIFF
--- a/boilerplate/client/src/components/App.js
+++ b/boilerplate/client/src/components/App.js
@@ -1,6 +1,5 @@
 import React, { Suspense } from 'react';
 import { Route, Switch } from "react-router-dom";
-import styled from 'styled-components';
 import Auth from "../hoc/auth";
 // pages for this product
 import NavBar from "./views/NavBar/NavBar";
@@ -19,34 +18,19 @@ import CartPage from './views/CartPage/CartPage';
 // false logged in user can't go inside
 
 function App() {
-  const Container = styled.div`
-    height: 100vh;
-    // background
-    padding: 6.5rem calc((100vw - 1193px) / 2 + 1rem);
-    @media screen and (max-width: 1193px) {
-      padding: 6.5rem 1rem;
-    }
-    @media screen and (max-width:767px) {
-      padding: 6.5rem 2rem;
-      flex-direction: column;
-    }
-  `;
-
   return (
     <Suspense fallback={(<div>Loading...</div>)}>
       <NavBar />
-      <Container>
-        <Switch>
-          <Route exact path="/" component={Auth(LandingPage, false)} />
-          <Route exact path="/login" component={Auth(LoginPage, false)} />
-          <Route exact path="/register" component={Auth(RegisterPage, false)} />
-          <Route exact path="/store" component={Auth(StorePage, null)} />
-          <Route exact path="/store/:storeId" component={Auth(ProductPage, null)} />
-          <Route exact path="/address" component={Auth(AddressPage, true)} />
-          <Route exact path="/favorite" component={Auth(FavoritePage, true)} />
-          <Route exact path="/cart" component={Auth(CartPage, true)} /> 
-        </Switch>
-      </Container>
+      <Switch>
+        <Route exact path="/" component={Auth(LandingPage, false)} />
+        <Route exact path="/login" component={Auth(LoginPage, false)} />
+        <Route exact path="/register" component={Auth(RegisterPage, false)} />
+        <Route exact path="/store" component={Auth(StorePage, null)} />
+        <Route exact path="/store/:storeId" component={Auth(ProductPage, null)} />
+        <Route exact path="/address" component={Auth(AddressPage, true)} />
+        <Route exact path="/favorite" component={Auth(FavoritePage, true)} />
+        <Route exact path="/cart" component={Auth(CartPage, true)} /> 
+      </Switch>
       <Footer />
     </Suspense>
   );

--- a/boilerplate/client/src/components/style/styledButton.js
+++ b/boilerplate/client/src/components/style/styledButton.js
@@ -1,0 +1,10 @@
+import styled from 'styled-components';
+
+
+const TextButton = styled.button`
+    background: none;
+    border: none;
+    cursor: pointer;
+`
+
+export { TextButton }

--- a/boilerplate/client/src/components/style/styledDiv.js
+++ b/boilerplate/client/src/components/style/styledDiv.js
@@ -1,0 +1,24 @@
+import styled from 'styled-components';
+
+
+const Container = styled.div`
+    height: 100vh;
+    padding: 7rem calc((100vw - 1193px) / 2 + 1rem);
+    @media screen and (max-width: 1193px) {
+        padding: 7rem 1rem;
+    }
+    @media screen and (max-width:767px) {
+        padding: 7rem 2rem;
+    }
+`;
+
+const EllipsisText = styled.div`
+    overflow: scroll;
+    text-overflow: ellipsis;
+    display: -webkit-box;
+    -webkit-line-clamp: 1; /* number of lines to show */
+    -webkit-box-orient: vertical;
+`;
+
+
+export { Container, EllipsisText }

--- a/boilerplate/client/src/components/utils/Postcode.js
+++ b/boilerplate/client/src/components/utils/Postcode.js
@@ -1,0 +1,134 @@
+/* global kakao */
+import React, { useState, useEffect, useRef } from 'react';
+import DaumPostcode from 'react-daum-postcode';
+import { Input } from 'antd';
+import styled from 'styled-components';
+
+
+function Postcode(props) {
+    const backdropEl = useRef()
+    const [isOpen, setOpen] = useState(false)
+
+    const handleComplete = (data) => {
+        let fullAddress = data.address;
+        let extraAddress = ''; 
+        
+        if (data.addressType === 'R') {
+          if (data.bname !== '') {
+            extraAddress += data.bname;
+          }
+          if (data.buildingName !== '') {
+            extraAddress += (extraAddress !== '' ? `, ${data.buildingName}` : data.buildingName);
+          }
+          fullAddress += (extraAddress !== '' ? ` (${extraAddress})` : '');
+        }
+
+        // 주소-좌표 변환 객체 생성
+        if (fullAddress) {
+            let geocoder = new window.kakao.maps.services.Geocoder();
+            // 주소로 좌표를 검색
+            geocoder.addressSearch(fullAddress, function(result, status) {
+                // 정상적으로 검색이 완료
+                if (status === window.kakao.maps.services.Status.OK) {
+                    let addressInfo = {
+                        x: parseFloat(result[0].x), 
+                        y: parseFloat(result[0].y),
+                        address_name: fullAddress,
+                        nickname: data.bname
+                    }
+
+                    props.handleCoords(addressInfo)
+                    setOpen(false)
+                }
+            })
+        }
+    }
+
+    const handleSearch = () => {
+        setOpen(true)
+    }
+
+    const handleClickOutside = ({ target }) => {
+        if (backdropEl.current && backdropEl.current.contains(target)) {
+            setOpen(false)
+        }
+    }
+
+    useEffect(() => {
+        window.addEventListener("click", handleClickOutside)
+        return () => {
+            window.removeEventListener("click", handleClickOutside)
+        }
+    }, [])
+
+    
+    const SearchWrapper = styled.div`
+        display: flex;
+        justify-content: center;
+        padding: 2rem;
+    `;
+
+    const PopupWrapper = styled.div`
+        position: absolute;
+        width: 90%;
+        max-width: 60rem;
+        height: auto;
+        top: 50%;
+        left: 50%;
+        transform: translate(-50%, -50%);
+        z-index: 99;
+    `;
+
+    const Backdrop = styled.div`
+        z-index: 9;
+        position: fixed;
+        display: flex;
+        align-items: center;
+        justify-content: center;
+        right: 0;
+        bottom: 0;
+        top: 0;
+        left: 0;
+        background-color: rgba(0, 0, 0, 0.5);
+        -webkit-tap-highlight-color: transparent;
+    `;
+
+    const SearchButton = styled.button`
+        background-color: #FFD30A;
+        padding-left: 1rem;
+        padding-right: 1rem;
+        border-radius: 0px 4px 4px 0px;
+        border: none;
+        cursor: pointer;
+        font-weight: 700;
+        &:hover {
+            color: white;
+        }
+    `;
+
+    return (
+        <React.Fragment>
+            <SearchWrapper>
+                <Input 
+                    style={{ width: '60%', borderRadius: "4px 0 0 4px", padding: "1.25rem" }} 
+                    value="아이가 식사를 할 위치를 입력해주세요!" 
+                    onClick={handleSearch} />
+                <SearchButton onClick={handleSearch}>검색</SearchButton>
+            </SearchWrapper>
+            {isOpen && 
+                <div>
+                <Backdrop ref={backdropEl} />
+                <PopupWrapper>
+                    <DaumPostcode
+                        onComplete={handleComplete}
+                        autoClose
+                        style={{ boxShadow: "rgba(100, 100, 111, 0.2) 0px 8px 24px 0px" }}
+                    />
+                </PopupWrapper>
+                </div>
+            }
+        </React.Fragment>
+    )
+}
+
+export default Postcode

--- a/boilerplate/client/src/components/views/AddressPage/AddressPage.js
+++ b/boilerplate/client/src/components/views/AddressPage/AddressPage.js
@@ -1,11 +1,13 @@
 import React, { useEffect, useState } from 'react';
 import { useDispatch } from 'react-redux';
-import Postcode from '../utils/Postcode';
+import Postcode from '../../utils/Postcode';
 import { Typography } from 'antd';
 import { addAddress, removeAddress, updateAddress } from '../../../_actions/user_actions';
 import AddressCard from './Sections/AddressCard';
+import { Container } from '../../style/styledDiv';
 
 const { Title } = Typography;
+
 
 function AddressPage(props) {
     const dispatch = useDispatch();
@@ -21,9 +23,6 @@ function AddressPage(props) {
     const handleCoords = (body) => {
         if (body && body.x && body.y && body.address_name) {
             dispatch(addAddress(body))
-            .then(response => {
-                console.log(response)
-            })
         }
     }
 
@@ -36,7 +35,8 @@ function AddressPage(props) {
     }
 
     return (
-        <React.Fragment>
+        <Container>
+            <br />
             <Postcode handleCoords={body => handleCoords(body)} />
             <Title level={3}>저장된 주소</Title>
             <AddressCard 
@@ -44,7 +44,7 @@ function AddressPage(props) {
                 removeItem={addressId => removeAddressItem(addressId)}
                 updateItem={(addressId, update) => updateAddressItem(addressId, update)}    
             />
-        </React.Fragment>
+        </Container>
     )
 }
 

--- a/boilerplate/client/src/components/views/CartPage/CartPage.js
+++ b/boilerplate/client/src/components/views/CartPage/CartPage.js
@@ -4,6 +4,8 @@ import { getCartItems, removeCartItem } from '../../../_actions/user_actions';
 import UserCardBlock from './Sections/UserCardBlock'
 import { Empty } from 'antd';
 import axios from 'axios'
+import { Container } from '../../style/styledDiv';
+
 
 function CartPage(props) {   
 
@@ -50,7 +52,7 @@ function CartPage(props) {
     }
 
     return (
-        <div style={{ width: '85%', margin: '3rem auto' }}>
+        <Container>
             <h1>My Cart</h1>
 
             <div>
@@ -68,7 +70,7 @@ function CartPage(props) {
                 </>
             }
 
-        </div>
+        </Container>
     )
 }
 

--- a/boilerplate/client/src/components/views/FavoritePage/FavoritePage.js
+++ b/boilerplate/client/src/components/views/FavoritePage/FavoritePage.js
@@ -3,7 +3,8 @@ import { useDispatch } from 'react-redux';
 import axios from 'axios';
 import { removeFavorite } from '../../../_actions/user_actions';
 import { Col, Card, Row, Typography, Empty, Button, Icon } from 'antd';
-import styled from 'styled-components';
+import { Container, EllipsisText } from '../../style/styledDiv';
+import { TextButton } from '../../style/styledButton';
 
 const { Title, Text } = Typography
 
@@ -44,20 +45,6 @@ function FavoritePage(props) {
     const removeFavoriteItem = (favoriteId) => {
         dispatch(removeFavorite(favoriteId))
     }
-    
-    const TextButton = styled.button`
-        background: none;
-        border: none;
-        cursor: pointer;
-    `
-
-    const EllipsisText = styled.div`
-        overflow: scroll;
-        text-overflow: ellipsis;
-        display: -webkit-box;
-        -webkit-line-clamp: 1; /* number of lines to show */
-        -webkit-box-orient: vertical;
-    `;
 
     const renderCards = stores.map((store, index) => {
         return (
@@ -103,31 +90,33 @@ function FavoritePage(props) {
     })
 
     return (
-        isEmpty ? (
-            <div>
-                <Empty
-                    image={Empty.PRESENTED_IMAGE_SIMPLE} 
-                    description={
-                    <div>
-                        찜한 가게가 없습니다.
-                    </div>
-                    }
-                >
-                    <Button type="primary" onClick={() => window.location.href='/store' }>
-                        가게 찜하러 가기
-                    </Button>
-                </Empty>
-            </div>
-        ) : (
-            <div>
-                <Title level={3}>찜한 가게 목록</Title>
-                <br />
-                {/* Cards */}
-                <Row gutter={[16, 16]}>
-                    {renderCards}
-                </Row>
-            </div>
-        )
+        <Container>
+            {isEmpty ? (
+                <div>
+                    <Empty
+                        image={Empty.PRESENTED_IMAGE_SIMPLE} 
+                        description={
+                        <div>
+                            찜한 가게가 없습니다.
+                        </div>
+                        }
+                    >
+                        <Button type="primary" onClick={() => window.location.href='/store' }>
+                            가게 찜하러 가기
+                        </Button>
+                    </Empty>
+                </div>
+            ) : (
+                <div>
+                    <Title level={3}>찜한 가게 목록</Title>
+                    <br />
+                    {/* Cards */}
+                    <Row gutter={[16, 16]}>
+                        {renderCards}
+                    </Row>
+                </div>
+            )}
+        </Container>
     )
 }
 

--- a/boilerplate/client/src/components/views/MyPage/MyPage.js
+++ b/boilerplate/client/src/components/views/MyPage/MyPage.js
@@ -1,4 +1,6 @@
 import React, { useEffect, useState } from 'react';
+import { Container } from '../../style/styledDiv';
+
 
 function Mypage() {
     const [historyInfo, setHistoryInfo] = useState([])
@@ -22,9 +24,9 @@ function Mypage() {
     }, [props.user.userData])
 
     return (
-        <div>
+        <Container>
             <h1> Mypage </h1>
-        </div>
+        </Container>
     )
 }
 

--- a/boilerplate/client/src/components/views/ProductPage/ProductPage.js
+++ b/boilerplate/client/src/components/views/ProductPage/ProductPage.js
@@ -1,12 +1,14 @@
 import React, { useEffect, useState } from 'react';
 import { useDispatch } from 'react-redux';
 import axios from 'axios';
-import { Col, Card, Row, Typography, Tabs, Icon, Empty } from 'antd';
+import { Card, Row, Typography, Tabs, Icon, Empty } from 'antd';
 import styled from 'styled-components';
 import MenuTab from './Sections/MenuTab';
 import ReviewTab from './Sections/ReviewTab';
 import InfoTab from './Sections/InfoTab';
 import { saveFavorite, removeFavorite } from '../../../_actions/user_actions';
+import { Container } from '../../style/styledDiv';
+import { TextButton } from '../../style/styledButton';
 
 const { Text } = Typography;
 const { TabPane } = Tabs;
@@ -65,19 +67,13 @@ function ProductPage(props) {
         }
     }
 
-    const TextButton = styled.button`
-        background: none;
-        border: none;
-        cursor: pointer;
-    `
-
     const TitleBox = styled.div`
         display: flex;
         justify-content: space-between;  
     `
 
     return (
-        <div>
+        <Container>
             {storeInfo && (
                 <Card
                     title={
@@ -136,7 +132,7 @@ function ProductPage(props) {
                     <InfoTab storeId={storeId} />
                 </TabPane>
             </Tabs>  
-        </div>        
+        </Container>      
     )
 }
 

--- a/boilerplate/client/src/components/views/ProductPage/Sections/MenuTab.js
+++ b/boilerplate/client/src/components/views/ProductPage/Sections/MenuTab.js
@@ -3,6 +3,7 @@ import { useDispatch, useSelector } from 'react-redux';
 import { Col, Card, Row, Typography, Collapse, Modal, Button, InputNumber, Tag, Popover, Icon } from 'antd';
 import styled from 'styled-components';
 import { addToCart } from '../../../../_actions/user_actions';
+import { EllipsisText } from '../../../style/styledDiv';
 
 const { Text, Title } = Typography;
 const { Panel } = Collapse;
@@ -83,14 +84,6 @@ function MenuTab(props) {
     const handleCancel = () => {
         setVisible(0)
     }
-
-    const EllipsisText = styled.div`
-        overflow: scroll;
-        text-overflow: ellipsis;
-        display: -webkit-box;
-        -webkit-line-clamp: 1; /* number of lines to show */
-        -webkit-box-orient: vertical;
-    `;
 
     const showTopFour = topFourItems && topFourItems.map((product, index) => {
         return (

--- a/boilerplate/client/src/components/views/StorePage/StorePage.js
+++ b/boilerplate/client/src/components/views/StorePage/StorePage.js
@@ -1,11 +1,11 @@
 import React, { useState, useEffect } from 'react';
 import axios from 'axios';
 import { Col, Card, Row, Typography, Empty, Button } from 'antd';
-import styled from 'styled-components';
 import Radiobox from './Sections/RadioBox';
 import SearchFeature from './Sections/SearchFeature';
 import { category } from './Sections/Data';
 import SortFeature from './Sections/SortFeature';
+import { Container, EllipsisText } from '../../style/styledDiv';
 
 const { Text } = Typography;
 
@@ -192,14 +192,6 @@ function StorePage(props) {
         setSort(!sort)
     }
 
-    const EllipsisText = styled.div`
-        overflow: scroll;
-        text-overflow: ellipsis;
-        display: -webkit-box;
-        -webkit-line-clamp: 1; /* number of lines to show */
-        -webkit-box-orient: vertical;
-    `;
-
     const renderCards = stores && stores.map((store, index) => {
         return (
             <Col sm={12} xs={24} key={index}>
@@ -244,59 +236,61 @@ function StorePage(props) {
     })
 
     return (
-        isEmpty && (props.user.userData && !props.user.userData.isAuth) ? (
-            <div>
-                <Empty
-                    image={Empty.PRESENTED_IMAGE_SIMPLE} 
-                    description={
-                    <span>
-                        가까운 지역 (500m) 안팎에 가맹점이 없습니다. <br />
-                        다른 주소를 입력해주세요.
-                    </span>
-                    }
-                >
-                    <Button type="primary" onClick={goToEnterAddress}>
-                        주소 입력하러가기
-                    </Button>
-                </Empty>
-            </div>                   
-        ) : (
-            <div>
-                {/* Filter */}
-                <Row gutter={[16, 16]}>
-                    {/* RadioBox */}
-                    <Col>
-                        <Radiobox list={category} handleFilters={selected => handleFilters(selected)} />
-                    </Col>
-                </Row>
+        <Container>
+            {isEmpty && (props.user.userData && !props.user.userData.isAuth) ? (
+                <div>
+                    <Empty
+                        image={Empty.PRESENTED_IMAGE_SIMPLE} 
+                        description={
+                        <span>
+                            가까운 지역 (500m) 안팎에 가맹점이 없습니다. <br />
+                            다른 주소를 입력해주세요.
+                        </span>
+                        }
+                    >
+                        <Button type="primary" onClick={goToEnterAddress}>
+                            주소 입력하러가기
+                        </Button>
+                    </Empty>
+                </div>                   
+            ) : (
+                <div>
+                    {/* Filter */}
+                    <Row gutter={[16, 16]}>
+                        {/* RadioBox */}
+                        <Col>
+                            <Radiobox list={category} handleFilters={selected => handleFilters(selected)} />
+                        </Col>
+                    </Row>
 
-                <div style={{ display: 'flex', justifyContent: 'space-between', margin: '1rem auto' }}>
-                    {/* Sort */}
-                    <SortFeature
-                        refreshFunction={updateSortTerm}
-                    />
-
-                    {/* Search */}
-                    <SearchFeature 
-                        refreshFunction={updateSearchTerm}
-                    />
-                </div>
-
-                {/* Cards */}
-                <Row gutter={[16, 16]}>
-                    {renderCards}
-                </Row>
-
-                {isEmpty ? (
-                    <div>
-                        <Empty
-                            image={Empty.PRESENTED_IMAGE_SIMPLE} 
-                            description="가까운 지역 (500m) 안팎에 가맹점이 없습니다."
+                    <div style={{ display: 'flex', justifyContent: 'space-between', margin: '1rem auto' }}>
+                        {/* Sort */}
+                        <SortFeature
+                            refreshFunction={updateSortTerm}
                         />
-                    </div>                
-                ) : null}
-            </div>
-        )
+
+                        {/* Search */}
+                        <SearchFeature 
+                            refreshFunction={updateSearchTerm}
+                        />
+                    </div>
+
+                    {/* Cards */}
+                    <Row gutter={[16, 16]}>
+                        {renderCards}
+                    </Row>
+
+                    {isEmpty ? (
+                        <div>
+                            <Empty
+                                image={Empty.PRESENTED_IMAGE_SIMPLE} 
+                                description="가까운 지역 (500m) 안팎에 가맹점이 없습니다."
+                            />
+                        </div>                
+                    ) : null}
+                </div>
+            )}
+        </Container>
     )
 }
 


### PR DESCRIPTION
`프론트엔드`
1. 스타일이 적용된 재사용 가능한 컴포넌트 생성 및 적용
```
/client/src/components/style
```
에 위치하였으며, styled-components로 제작됨

`styledDiv`는 div 태그에 스타일 적용한 것
- Container 는 랜딩 페이지, 로그인 페이지, 회원가입 페이지를 제외한 모든 상위 페이지를 담는 컨테이너
- EllipsisText 는 텍스트가 한 줄을 넘어갔을 때 생략하고 싶은 경우 사용

`styledButton`은 button 태그에 스타일 적용한 것
- TextButton 은 버튼에 아이콘 넣고 싶은 경우 사용 (antd의 `Button type="text"` 가 작동하지 않아서 제작)

사용법은 antd와 유사, ProductPage 참고할 것
```
import { Container } from '../../style/styledDiv';
import { TextButton } from '../../style/styledButton';
```
