### PR TITLE
Update reviews

### DIFF
--- a/boilerplate/client/src/components/views/FavoritePage/FavoritePage.js
+++ b/boilerplate/client/src/components/views/FavoritePage/FavoritePage.js
@@ -1,5 +1,6 @@
 import React, { useState, useEffect } from 'react';
 import { useDispatch } from 'react-redux';
+import { Link } from 'react-router-dom';
 import axios from 'axios';
 import { removeFavorite } from '../../../_actions/user_actions';
 import { Col, Card, Row, Typography, Empty, Button, Icon } from 'antd';
@@ -55,33 +56,33 @@ function FavoritePage(props) {
                         hoverable
                     >
                         
-                        <a href={`/store/${store._id}`} style={{ color: "black", textDecoration: "none" }}>
+                        <Link to={`/store/${store._id}`} style={{ color: "black", textDecoration: "none" }}>
                             <Row gutter={[16, 16]}>
-                                <Col lg={10} md={24}>
+                                <Col lg={9} md={24}>
                                     <img style={{ height: "150px", width: "150px" }} src={store.storeImages} />
                                 </Col>
-                                <Col lg={14} md={24}>
+                                <Col lg={15} md={24}>
                                     <Row>
-                                        <Text strong>별점 </Text>{parseFloat(store.ratings)}
+                                        <Text strong style={{ paddingBottom: "1rem" }}>별점&nbsp;&nbsp;</Text>
+                                        { store.reviews ? (
+                                            parseFloat(store.reviews.ratings) / store.reviews.count
+                                        ) : ( "-" ) 
+                                        }
                                     </Row>
-                                    <Row style={{ marginTop: "0.5rem" }}>
-                                        <Text strong>거리</Text>
-                                        <div>주소로부터 {parseInt(store.distance)} m</div>
-                                    </Row>
-                                    <Row style={{ marginTop: "0.5rem" }}>
-                                        <Text strong>설명</Text>
+                                    <Row style={{ marginTop: "0.5rem", display: "flex" }}>
+                                        <Text strong>설명&nbsp;&nbsp;</Text>
                                         <EllipsisText>{store.storeDescription}</EllipsisText>
                                     </Row>
                                     <Row style={{ marginTop: "0.5rem" }}>
                                         {store.sanitary ? 
                                             <Text mark>위생인증가게</Text>
                                             :
-                                            <Text disabled>위생인증</Text>
+                                            <Text>&nbsp;</Text>
                                         }
                                     </Row>
                                 </Col>
                             </Row>
-                        </a>
+                        </Link>
 
                     </Card>
             

--- a/boilerplate/client/src/components/views/LandingPage/LandingPage.js
+++ b/boilerplate/client/src/components/views/LandingPage/LandingPage.js
@@ -75,7 +75,7 @@ function LandingPage(props) {
         font-size: 2rem;
         font-weight: 900;
         color: black;
-        padding-bottom: 1rem;
+        padding-top: 1rem;
     `;
 
     const SubTitle = styled.div`
@@ -102,10 +102,10 @@ function LandingPage(props) {
             </Background>
             <Container>
                 <div>
-                    <TitleLeft>우리 아이 <br /> 밥심(心)</TitleLeft>
                     <SubTitle>
-                        나를 대신해 건강한 밥 한끼를 챙겨줄 사람이 없을까?
+                        나를 대신해 건강한 밥 한끼를 챙겨줄,
                     </SubTitle>
+                    <TitleLeft>우리 아이 <br /> 밥심(心)</TitleLeft>
                     <br />
                 </div>
                 <div style={{ display: "flex", alignItems: "start" }}>

--- a/boilerplate/client/src/components/views/ProductPage/ProductPage.js
+++ b/boilerplate/client/src/components/views/ProductPage/ProductPage.js
@@ -20,6 +20,7 @@ function ProductPage(props) {
     const [products, setProducts] = useState([])
     const [storeInfo, setStoreInfo] = useState()
     const [isFavorite, setIsFavorite] = useState(false)
+    const [distance, setDistance] = useState(0)
 
     useEffect(() => {   
         let body = { 
@@ -35,6 +36,7 @@ function ProductPage(props) {
         axios.post(`/api/stores/getStoreInfo`, body)
         .then(response => {
             setStoreInfo(response.data.storeInfo[0])
+            props.location?.state?.distance && setDistance(props.location.state.distance)
         })
         .catch(err => alert(err))
 
@@ -72,6 +74,13 @@ function ProductPage(props) {
         justify-content: space-between;  
     `
 
+    const Content = styled.div`
+        padding: 0 0 0 1rem;
+        @media screen and (max-width: 432px) {
+            padding: 0.5rem 0 0 0;
+        }
+    `;
+
     return (
         <Container>
             {storeInfo && (
@@ -90,15 +99,19 @@ function ProductPage(props) {
                         <div>
                             <img src={storeInfo.storeImages} style={{ height: "100px", width: "100px" }} />
                         </div>
-                        <div style={{ paddingLeft: "1rem" }}>
+                        <Content>
                             <div>
-                                <Text strong>별점 </Text>{parseFloat(storeInfo.ratings)}
+                                <Text strong>별점&nbsp;&nbsp;</Text>
+                                { storeInfo.reviews ? (
+                                    parseFloat(storeInfo.reviews.ratings) / storeInfo.reviews.count
+                                ) : ( "-" ) 
+                                }
                             </div>
                             <div style={{ marginTop: "0.25rem" }}>
-                                <Text strong>거리 </Text><Text>주소로부터 {parseInt(storeInfo.distance)} m</Text>
+                                <Text strong>거리&nbsp;&nbsp;</Text><Text>주소로부터 {parseInt(distance)} m</Text>
                             </div>
                             <div style={{ marginTop: "0.25rem" }}>
-                                <Text strong>설명 </Text><Text>{storeInfo.storeDescription}</Text>
+                                <Text strong>설명&nbsp;&nbsp;</Text><Text>{storeInfo.storeDescription}</Text>
                             </div>
                             <div style={{ marginTop: "0.25rem" }}>
                                 {storeInfo.sanitary ? 
@@ -107,7 +120,7 @@ function ProductPage(props) {
                                     null
                                 }
                             </div>
-                        </div>
+                        </Content>
                     </Row>
                 </Card>        
             )}
@@ -126,7 +139,7 @@ function ProductPage(props) {
                     )}
                 </TabPane>
                 <TabPane tab="클린리뷰" key="2">
-                    <ReviewTab />
+                    <ReviewTab storeId={storeId} />
                 </TabPane>
                 <TabPane tab="정보" key="3">
                     <InfoTab storeId={storeId} />

--- a/boilerplate/client/src/components/views/ProductPage/ProductPage.js
+++ b/boilerplate/client/src/components/views/ProductPage/ProductPage.js
@@ -107,9 +107,12 @@ function ProductPage(props) {
                                 ) : ( "-" ) 
                                 }
                             </div>
-                            <div style={{ marginTop: "0.25rem" }}>
-                                <Text strong>거리&nbsp;&nbsp;</Text><Text>주소로부터 {parseInt(distance)} m</Text>
-                            </div>
+                            { distance ?
+                                <div style={{ marginTop: "0.25rem" }}>
+                                    <Text strong>거리&nbsp;&nbsp;</Text>
+                                    <Text>주소로부터 {parseInt(distance)} m</Text>
+                                </div>
+                            : null }
                             <div style={{ marginTop: "0.25rem" }}>
                                 <Text strong>설명&nbsp;&nbsp;</Text><Text>{storeInfo.storeDescription}</Text>
                             </div>

--- a/boilerplate/client/src/components/views/ProductPage/Sections/InfoTab.js
+++ b/boilerplate/client/src/components/views/ProductPage/Sections/InfoTab.js
@@ -67,7 +67,7 @@ function InfoTab(props) {
                             {storeInfo.sanitary ? 
                                 <Text mark>위생인증가게</Text>
                                 :
-                                <Text disabled>X</Text>
+                                <Text disabled>-</Text>
                             }
                         </Row>
                     </Card>

--- a/boilerplate/client/src/components/views/ProductPage/Sections/ReviewTab.js
+++ b/boilerplate/client/src/components/views/ProductPage/Sections/ReviewTab.js
@@ -1,36 +1,29 @@
 import React, { useEffect, useState } from 'react';
-import { useSelector } from 'react-redux';
 import { Typography, Rate, Empty } from 'antd';
 import styled from 'styled-components';
+import axios from 'axios';
 
 const { Title, Text } = Typography;
 
 
-function ReviewTab() {
-    const user = useSelector(state => state.user)
-    const [ratings, setTableRowRatings] = useState(0.0)
-    const [reviews, setTableRowReviews] = useState({})
+function ReviewTab(props) {
+    const [ratings, setRatings] = useState(0.0)
+    const [reviews, setReviews] = useState({})
 
     useEffect(() => {
-        if (user.userData && user.userData.ratings && user.userData.reviews) {
-            setTableRowRatings(user.userData.ratings)
-            setTableRowReviews(user.userData.reviews)
-            alert(user.userData.reviews)
+        let body = { 
+            store: props.storeId
         }
-        else {
-            /* FOR TEST
 
-            setTableRowatings(4.9)
-            setTableRoweviews({ 
-                first: {green: 8, yellow: 7, orange: 0 },
-                second: {green: 7, yellow: 5, orange: 3 },
-                third: {green: 3, yellow: 10, orange: 2 },
-                fourth: {green: 10, yellow: 5, orange: 1 },
-                fifth: {green: 5, yellow: 10, orange: 0 }
-            })
-            
-            */
-        }
+        axios.post(`/api/stores/getStoreInfo`, body)
+        .then(response => {
+            let storeInfo = response.data.storeInfo[0]
+            if (storeInfo && storeInfo.reviews) {
+                setRatings(storeInfo.reviews.ratings / storeInfo.reviews.count)
+                setReviews(storeInfo.reviews)    
+            }
+        })
+        .catch(err => alert(err))
     }, [])
  
     return (

--- a/boilerplate/client/src/components/views/StorePage/StorePage.js
+++ b/boilerplate/client/src/components/views/StorePage/StorePage.js
@@ -1,4 +1,5 @@
 import React, { useState, useEffect } from 'react';
+import { Link } from 'react-router-dom';
 import axios from 'axios';
 import { Col, Card, Row, Typography, Empty, Button } from 'antd';
 import Radiobox from './Sections/RadioBox';
@@ -195,7 +196,10 @@ function StorePage(props) {
     const renderCards = stores && stores.map((store, index) => {
         return (
             <Col sm={12} xs={24} key={index}>
-                <a href={`/store/${store._id}`}>
+                <Link to={{
+                    pathname: `/store/${store._id}`,
+                    state: { distance: store.distance }
+                }}>
                     <Card
                         title={store.storeName}
                         hoverable
@@ -210,7 +214,11 @@ function StorePage(props) {
                             </Col>
                             <Col lg={15} md={24}>
                                 <Row>
-                                    <Text strong>별점 {store.ratings}</Text>
+                                    <Text strong>별점&nbsp;&nbsp;</Text>
+                                    { store.reviews ? (
+                                        parseFloat(store.reviews.ratings) / store.reviews.count
+                                    ) : ( "-" ) 
+                                    }
                                 </Row>
                                 <Row style={{ marginTop: "0.5rem" }}>
                                     <Text strong>거리</Text>
@@ -230,7 +238,7 @@ function StorePage(props) {
                             </Col>
                         </Row>
                     </Card>
-                </a>
+                </Link>
             </Col>
         );
     })

--- a/boilerplate/server/models/Store.js
+++ b/boilerplate/server/models/Store.js
@@ -38,9 +38,6 @@ const storeSchema = mongoose.Schema({
         type: Boolean,
         default: false
     },
-    ratings: {
-        type: Number
-    },
     storeOwner: {// 사업자 정보
         ownerName: String, 
         tradeName: String, 
@@ -51,7 +48,7 @@ const storeSchema = mongoose.Schema({
         default: 0
     },
     reviews: {
-        type: Array
+        type: Object
     }
 }, { timestamps: true });
 

--- a/boilerplate/server/routes/products.js
+++ b/boilerplate/server/routes/products.js
@@ -29,7 +29,6 @@ router.get('/products_by_id', (req, res) => {
 
     // productId를 이용해서 DB에서 productId와 같은 상품 정보를 가져온다.
     Product.find({ _id: {$in: productIds }})
-    .populate('writer')
     .exec((err, product) => {
         if (err) return res.status(400).send(err)
         return res.status(200).send(product)

--- a/boilerplate/server/routes/stores.js
+++ b/boilerplate/server/routes/stores.js
@@ -147,7 +147,24 @@ router.post('/addReview', auth, (req, res) => {
             });
         }
     )
-        
 });
+
+/*가게 판매량 업데이트*/
+router.post('/updateStoreSold', auth, (req, res) => {
+    Store.findOneAndUpdate(
+        { "_id": req.body.storeId },
+        {
+            $inc: { "sold": 1 }
+        },
+        { new: true },
+        (err, storeInfo) => {
+            if (err) return res.status(400).json({success: false, err});
+            return res.status(200).json({
+                success: true,
+                storeInfo
+            });
+        }
+    );
+})
 
 module.exports = router;

--- a/boilerplate/server/routes/stores.js
+++ b/boilerplate/server/routes/stores.js
@@ -1,8 +1,6 @@
 const express = require('express');
 const router = express.Router();
 const { Store } = require("../models/Store");
-const {Product} = require("../models/Product");
-const { User } = require("../models/User");
 const { auth } = require("../middleware/auth");
 
 
@@ -112,20 +110,33 @@ router.post('/getFavorites', auth, (req, res) => {
 /*리뷰작성*/
 router.post('/addReview', auth, (req, res) => {
     let storeId = req.body.storeId;
-    let ratings = req.body.ratings;
     let reviews = req.body.reviews;
 
     Store.findOneAndUpdate(
         { "_id": storeId },
-        { $push: {
-            ratings: ratings,
-            reviews: {
-                first: reviews.first,
-                second: reviews.second,
-                third: reviews.third,
-                fourth: reviews.fourth,
-                fifth: reviews.fifth
-            }
+        { $inc: {
+            "reviews.count": 1,
+            "reviews.ratings": reviews.ratings,
+
+            "reviews.first.green": reviews.first.green,
+            "reviews.first.yellow": reviews.first.yellow,
+            "reviews.first.orange": reviews.first.orange,
+
+            "reviews.second.green": reviews.second.green,
+            "reviews.second.yellow": reviews.second.yellow,
+            "reviews.second.orange": reviews.second.orange,
+
+            "reviews.third.green": reviews.third.green,
+            "reviews.third.yellow": reviews.third.yellow,
+            "reviews.third.orange": reviews.third.orange,
+
+            "reviews.fourth.green": reviews.fourth.green,
+            "reviews.fourth.yellow": reviews.fourth.yellow,
+            "reviews.fourth.orange": reviews.fourth.orange,
+
+            "reviews.fifth.green": reviews.fifth.green,
+            "reviews.fifth.yellow": reviews.fifth.yellow,
+            "reviews.fifth.orange": reviews.fifth.orange,
         } },
         { new: true },
         (err, storeInfo) => {

--- a/boilerplate/server/routes/users.js
+++ b/boilerplate/server/routes/users.js
@@ -271,7 +271,6 @@ router.get('/removeFromCart', auth, (req, res) => {
 
             // product Collection에 현재 남아있는 상품들의 정보를 가져오기
             Product.find({ _id: { $in: array }})
-            .populate('writer')
             .exec((err, productInfo) => {
                 return res.status(200).json({
                     productInfo,
@@ -382,7 +381,7 @@ router.post('/successBuy', auth, (req, res) => {
 //            MyPage
 //=================================
 /*상품 사용 완료*/
-router.post('/successUse', auth, (req, res) => {
+router.post('/successUse', auth, (req, res) => {    
     User.findOneAndUpdate(
         { _id: req.user._id, "history.id": req.body.id },
         {
@@ -395,7 +394,8 @@ router.post('/successUse', auth, (req, res) => {
             success: true,
                 userInfo
             });
-        });
+        }
+    );
 });
 
 


### PR DESCRIPTION
`백엔드`
1. 리뷰 추가 및 리뷰 보여주기를 위해 User collection의 reviews field 수정 & addReview router 수정
- 리뷰 추가할 때 보내줄 양식
```
{
    "storeId": "60f0f28a80203ceb76c34654",
    "reviews": {
        "ratings": 5.0,
        "first": {
            "green": 1,
            "yellow": 0,
            "orange": 0
        },
        "second": {
            "green": 1,
            "yellow": 0,
            "orange": 0
        },
        "third": {
            "green": 0,
            "yellow": 1,
            "orange": 0
        },
        "fourth": {
            "green": 1,
            "yellow": 0,
            "orange": 0
        },
        "fifth": {
            "green": 1,
            "yellow": 0,
            "orange": 0
        }
    }
}
```
- 프로토타입을 보면 green, yellow, orange는 이해가 갈 것
- 리뷰 남길 때 green을 선택했으면, green에 1, 나머지에 해당하는 yellow, orange에는 0 담아서 보내주기 바람

2. 가게 판매량 업데이트하는 router 구현
- 상품 사용 완료 시에 `/api/users/successUse`에는 해당 history id를, **`/api/stores/updateStoreSold`에는 storeId를 보내주기 바람**
- Product collection의 sold는 상품이 판매될 때 (successBuy) 업데이트하는 반면, Store collection의 sold는 상품 사용 완료 시에 업데이트 (어떤 상품이 인기가 좋은지 알기 위해서는 어떤 상품을 구매하는지 보면 되고, 어떤 가게가 인기가 좋은지 알기 위해서는 실제로 해당 가게의 상품을 이용한 횟수가 얼마나 많은지 아는게 좋기 때문에, 가게의 sold는 사용 완료 후에 업데이트하게 함)

`프론트엔드`
1. StorePage에서 계산한 주소로부터 가게까지의 **거리**를  ProductPage에 전달
**FavoritePage(찜하기 페이지)에서는 거리를 보여주지 않아야해서 보여주지 않았고, FavoritePage에서 찜한 가게를 눌러서 StorePage(가게 페이지)에 들어간 경우에는 거리를 보여주지 않음**
2. 회의 때 제안된 UI 수정안 반영